### PR TITLE
Feature/post

### DIFF
--- a/src/main/java/apptive/team1/friendly/domain/post/controller/PostController.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/controller/PostController.java
@@ -67,7 +67,7 @@ public class PostController {
      */
     @GetMapping("/posts/{postId}")
     public ResponseEntity<PostDto> postDetail(@PathVariable("postId") Long postId) {
-        PostDto postDto = postService.setPostDto(postId);
+        PostDto postDto = postService.postDetail(postId);
 
         return new ResponseEntity<>(postDto, HttpStatus.OK);
     }

--- a/src/main/java/apptive/team1/friendly/domain/post/controller/PostController.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/controller/PostController.java
@@ -5,6 +5,7 @@ import apptive.team1.friendly.domain.post.dto.PostFormDto;
 import apptive.team1.friendly.domain.post.dto.PostListDto;
 import apptive.team1.friendly.domain.post.entity.Post;
 import apptive.team1.friendly.domain.post.service.PostService;
+import apptive.team1.friendly.domain.user.data.dto.PostOwnerInfo;
 import apptive.team1.friendly.domain.user.data.repository.AccountRepository;
 import apptive.team1.friendly.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +20,7 @@ import java.util.List;
 public class PostController {
 
     private final PostService postService;
-
+    private final UserService userService;
     /**
      * 게시물 추가
      */
@@ -67,7 +68,8 @@ public class PostController {
      */
     @GetMapping("/posts/{postId}")
     public ResponseEntity<PostDto> postDetail(@PathVariable("postId") Long postId) {
-        PostDto postDto = postService.postDetail(postId);
+        PostOwnerInfo postOwnerInfo = userService.getPostOwnerInfo(postId);
+        PostDto postDto = postService.postDetail(postId, postOwnerInfo);
 
         return new ResponseEntity<>(postDto, HttpStatus.OK);
     }

--- a/src/main/java/apptive/team1/friendly/domain/post/controller/PostController.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/controller/PostController.java
@@ -19,8 +19,6 @@ import java.util.List;
 public class PostController {
 
     private final PostService postService;
-    private final AccountRepository accountRepository;
-    private final UserService userService;
 
     /**
      * 게시물 추가

--- a/src/main/java/apptive/team1/friendly/domain/post/dto/CommentDto.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/dto/CommentDto.java
@@ -1,0 +1,17 @@
+package apptive.team1.friendly.domain.post.dto;
+
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Data
+public class CommentDto {
+
+    private String username;
+
+    private String text;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime createTime;
+}

--- a/src/main/java/apptive/team1/friendly/domain/post/dto/PostDto.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/dto/PostDto.java
@@ -1,11 +1,10 @@
 package apptive.team1.friendly.domain.post.dto;
 
 import apptive.team1.friendly.domain.post.entity.Comment;
+import apptive.team1.friendly.domain.user.data.dto.profile.LanguageDto;
+import apptive.team1.friendly.domain.user.data.dto.profile.NationDto;
 import apptive.team1.friendly.domain.user.data.dto.profile.ProfileImgDto;
-import apptive.team1.friendly.domain.user.data.entity.profile.AccountLanguage;
-import apptive.team1.friendly.domain.user.data.entity.profile.AccountNation;
-import apptive.team1.friendly.domain.user.data.entity.profile.Language;
-import apptive.team1.friendly.domain.user.data.entity.profile.ProfileImg;
+import apptive.team1.friendly.domain.user.data.entity.profile.*;
 import apptive.team1.friendly.global.common.s3.FileInfo;
 import apptive.team1.friendly.domain.post.entity.HashTag;
 import apptive.team1.friendly.domain.user.data.dto.AccountInfoResponse;
@@ -32,9 +31,11 @@ public class PostDto {
 
     private String lastName;
 
-    private String nation;
+    private Gender gender; // gender를 클래스로 쓸건지
 
-    private List<String> languages;
+    private NationDto nationDto;
+
+    private List<LanguageDto> languageDtoList;
 
     private ProfileImgDto profileImgDto;
 

--- a/src/main/java/apptive/team1/friendly/domain/post/dto/PostDto.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/dto/PostDto.java
@@ -1,16 +1,7 @@
 package apptive.team1.friendly.domain.post.dto;
 
-import apptive.team1.friendly.domain.post.entity.Comment;
 import apptive.team1.friendly.domain.user.data.dto.PostOwnerInfo;
-import apptive.team1.friendly.domain.user.data.dto.profile.LanguageDto;
-import apptive.team1.friendly.domain.user.data.dto.profile.NationDto;
-import apptive.team1.friendly.domain.user.data.dto.profile.ProfileImgDto;
-import apptive.team1.friendly.domain.user.data.entity.profile.*;
-import apptive.team1.friendly.global.common.s3.FileInfo;
 import apptive.team1.friendly.domain.post.entity.HashTag;
-import apptive.team1.friendly.domain.user.data.dto.AccountInfoResponse;
-import apptive.team1.friendly.domain.user.data.entity.Account;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/src/main/java/apptive/team1/friendly/domain/post/dto/PostDto.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/dto/PostDto.java
@@ -1,6 +1,7 @@
 package apptive.team1.friendly.domain.post.dto;
 
 import apptive.team1.friendly.domain.post.entity.Comment;
+import apptive.team1.friendly.domain.user.data.dto.profile.ProfileImgDto;
 import apptive.team1.friendly.domain.user.data.entity.profile.AccountLanguage;
 import apptive.team1.friendly.domain.user.data.entity.profile.AccountNation;
 import apptive.team1.friendly.domain.user.data.entity.profile.Language;
@@ -31,11 +32,11 @@ public class PostDto {
 
     private String lastName;
 
-    private AccountNation accountNation;
+    private String nation;
 
-    private List<AccountLanguage> accountLanguages;
+    private List<String> languages;
 
-    private ProfileImg profileImg;
+    private ProfileImgDto profileImgDto;
 
     private String title;
 

--- a/src/main/java/apptive/team1/friendly/domain/post/dto/PostDto.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/dto/PostDto.java
@@ -17,7 +17,6 @@ import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Set;
 
 @Getter @Setter

--- a/src/main/java/apptive/team1/friendly/domain/post/dto/PostDto.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/dto/PostDto.java
@@ -1,6 +1,7 @@
 package apptive.team1.friendly.domain.post.dto;
 
 import apptive.team1.friendly.domain.post.entity.Comment;
+import apptive.team1.friendly.domain.user.data.dto.PostOwnerInfo;
 import apptive.team1.friendly.domain.user.data.dto.profile.LanguageDto;
 import apptive.team1.friendly.domain.user.data.dto.profile.NationDto;
 import apptive.team1.friendly.domain.user.data.dto.profile.ProfileImgDto;
@@ -25,18 +26,7 @@ public class PostDto {
 
     private Long postId;
 
-    // 방장 정보
-    private String firstName;
-
-    private String lastName;
-
-//    private Gender gender; // gender를 클래스로 쓸건지
-
-    private NationDto nationDto;
-
-    private List<LanguageDto> languageDtoList;
-
-    private ProfileImgDto profileImgDto;
+    private PostOwnerInfo postOwnerInfo;
 
     private String title;
 

--- a/src/main/java/apptive/team1/friendly/domain/post/dto/PostDto.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/dto/PostDto.java
@@ -16,7 +16,6 @@ import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -31,7 +30,7 @@ public class PostDto {
 
     private String lastName;
 
-    private Gender gender; // gender를 클래스로 쓸건지
+//    private Gender gender; // gender를 클래스로 쓸건지
 
     private NationDto nationDto;
 

--- a/src/main/java/apptive/team1/friendly/domain/post/dto/PostDto.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/dto/PostDto.java
@@ -1,5 +1,10 @@
 package apptive.team1.friendly.domain.post.dto;
 
+import apptive.team1.friendly.domain.post.entity.Comment;
+import apptive.team1.friendly.domain.user.data.entity.profile.AccountLanguage;
+import apptive.team1.friendly.domain.user.data.entity.profile.AccountNation;
+import apptive.team1.friendly.domain.user.data.entity.profile.Language;
+import apptive.team1.friendly.domain.user.data.entity.profile.ProfileImg;
 import apptive.team1.friendly.global.common.s3.FileInfo;
 import apptive.team1.friendly.domain.post.entity.HashTag;
 import apptive.team1.friendly.domain.user.data.dto.AccountInfoResponse;
@@ -13,29 +18,28 @@ import org.springframework.format.annotation.DateTimeFormat;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @Getter @Setter
 @NoArgsConstructor
 public class PostDto {
 
-    public PostDto(Long id, AccountInfoResponse accountInfo, String title, List<HashTag> hashTag, int maxPeople, String description, LocalDateTime promiseTime, String location, List<String> rules) {
-        this.accountInfo = accountInfo;
-        this.postId = id;
-        this.title = title;
-        this.hashTag = hashTag;
-        this.maxPeople = maxPeople;
-        this.description = description;
-        this.promiseTime = promiseTime;
-        this.location = location;
-        this.rules = rules;
-    }
     private Long postId;
 
-    private AccountInfoResponse accountInfo;
+    // 방장 정보
+    private String firstName;
+
+    private String lastName;
+
+    private AccountNation accountNation;
+
+    private List<AccountLanguage> accountLanguages;
+
+    private ProfileImg profileImg;
 
     private String title;
 
-    private List<HashTag> hashTag = new ArrayList<HashTag>();
+    private Set<HashTag> hashTag;
 
     private int maxPeople;
 
@@ -46,6 +50,8 @@ public class PostDto {
 
     private String location;
 
-    private List<String> rules = new ArrayList<String>();
+    private Set<String> rules;
+
+    private Set<CommentDto> comments;
 
 }

--- a/src/main/java/apptive/team1/friendly/domain/post/dto/PostFormDto.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/dto/PostFormDto.java
@@ -10,7 +10,9 @@ import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Getter @Setter
 @NoArgsConstructor
@@ -19,7 +21,7 @@ public class PostFormDto {
     /**
      * 새로 글 쓰는 경우 생성자. postId가 없음
      */
-    public PostFormDto(String title, List<HashTag> hashTag, int maxPeople, String description, LocalDateTime promiseTime, String location, List<String> rules) {
+    public PostFormDto(String title, Set<HashTag> hashTag, int maxPeople, String description, LocalDateTime promiseTime, String location, Set<String> rules) {
         this.title = title;
         this.hashTag = hashTag;
         this.maxPeople = maxPeople;
@@ -47,7 +49,7 @@ public class PostFormDto {
 
     private String title;
 
-    private List<HashTag> hashTag = new ArrayList<HashTag>();
+    private Set<HashTag> hashTag = new HashSet<>();
 
     private int maxPeople;
 
@@ -58,7 +60,7 @@ public class PostFormDto {
 
     private String location;
 
-    private List<String> rules = new ArrayList<String>();
+    private Set<String> rules = new HashSet<>();
 
     // 이미지 필드
     private FileInfo fileInfo;

--- a/src/main/java/apptive/team1/friendly/domain/post/dto/PostListDto.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/dto/PostListDto.java
@@ -1,5 +1,6 @@
 package apptive.team1.friendly.domain.post.dto;
 
+import apptive.team1.friendly.domain.user.data.dto.profile.ProfileImgDto;
 import apptive.team1.friendly.global.common.s3.FileInfo;
 import apptive.team1.friendly.domain.post.entity.HashTag;
 import lombok.Getter;
@@ -28,6 +29,6 @@ public class PostListDto {
     private Set<HashTag> hashTag = new HashSet<>();
 
     // 이미지 필드
-    private FileInfo fileInfo;
+    private ProfileImgDto profileImgDto;
 
 }

--- a/src/main/java/apptive/team1/friendly/domain/post/dto/PostListDto.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/dto/PostListDto.java
@@ -8,7 +8,9 @@ import lombok.Setter;
 import javax.persistence.Column;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Getter @Setter
 public class PostListDto {
@@ -23,7 +25,7 @@ public class PostListDto {
 
     private String location;
 
-    private List<HashTag> hashTag = new ArrayList<HashTag>();
+    private Set<HashTag> hashTag = new HashSet<>();
 
     // 이미지 필드
     private FileInfo fileInfo;

--- a/src/main/java/apptive/team1/friendly/domain/post/dto/PostListDto.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/dto/PostListDto.java
@@ -1,16 +1,12 @@
 package apptive.team1.friendly.domain.post.dto;
 
 import apptive.team1.friendly.domain.user.data.dto.profile.ProfileImgDto;
-import apptive.team1.friendly.global.common.s3.FileInfo;
 import apptive.team1.friendly.domain.post.entity.HashTag;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.persistence.Column;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 @Getter @Setter

--- a/src/main/java/apptive/team1/friendly/domain/post/entity/AccountPost.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/entity/AccountPost.java
@@ -20,21 +20,14 @@ public class AccountPost {
     @GeneratedValue(strategy = GenerationType.IDENTITY) // 기본 키 생성을 데이터 베이스에 위임 MySQL Auto_Increment
     private Long id;
 
-    @ManyToOne(cascade = CascadeType.ALL, fetch = LAZY) // 실제로 Post 객체가 필요 할 때 fetch. AccountPost 조회할 때 같이 fetch 하지 않음
+    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY) // 실제로 Post 객체가 필요 할 때 fetch. AccountPost 조회할 때 같이 fetch 하지 않음
     // CascadeType.ALL 이므로 AccountPost가 저장되거나 삭제될 때 Post도 함께 저장되고 삭제 됨
     @JoinColumn(name = "post_id") // 연관관계의 주인
     private Post post;
 
-    @ManyToOne(fetch = LAZY) // Cascade안해도 되지 않나? user는 AccountPost를 알지 못 함
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "user_id") // 연관관계의 주인
     private Account user;
-
-
-//    @Override
-//    public boolean equals(Object o) {
-//        AccountPost accountPost = (AccountPost) o;
-//        return this.id == accountPost.id;
-//    }
 
 
 }

--- a/src/main/java/apptive/team1/friendly/domain/post/entity/Comment.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/entity/Comment.java
@@ -1,6 +1,7 @@
 package apptive.team1.friendly.domain.post.entity;
 
 import apptive.team1.friendly.domain.user.data.entity.Account;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -27,7 +28,7 @@ public class Comment {
     private Account account;
 
     @JoinColumn(name = "post_id")
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
     private Post post;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")

--- a/src/main/java/apptive/team1/friendly/domain/post/entity/Post.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/entity/Post.java
@@ -1,17 +1,11 @@
 package apptive.team1.friendly.domain.post.entity;
 
-import apptive.team1.friendly.global.common.s3.FileInfo;
-import com.fasterxml.jackson.annotation.JsonBackReference;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
-
 import javax.persistence.*;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 
 @Entity

--- a/src/main/java/apptive/team1/friendly/domain/post/entity/Post.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/entity/Post.java
@@ -1,22 +1,25 @@
 package apptive.team1.friendly.domain.post.entity;
 
 import apptive.team1.friendly.global.common.s3.FileInfo;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 @Entity
 @Getter @Setter
 @NoArgsConstructor
 public class Post {
 
-    public Post(String title, String description, int maxPeople, LocalDateTime promiseTime, String location, List<String> rules, List<HashTag> hashTag) {
+    public Post(String title, String description, int maxPeople, LocalDateTime promiseTime, String location, Set<String> rules, Set<HashTag> hashTag) {
         this.title = title;
         this.description = description;
         this.maxPeople = maxPeople;
@@ -39,7 +42,7 @@ public class Post {
 
     private int maxPeople;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime promiseTime;
 
     private String location;
@@ -47,13 +50,13 @@ public class Post {
 
     // 게시글에 들어가야 보이는 필드
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.LAZY)
     @Enumerated(EnumType.STRING)
-    private List<HashTag> hashTag = new ArrayList<HashTag>();
+    private Set<HashTag> hashTag;
 
-    @ElementCollection
-    private List<String> rules = new ArrayList<String>();
+    @ElementCollection(fetch = FetchType.LAZY)
+    private Set<String> rules;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL) // Post 저장시 연관되어 있는 Comment들도 함께 저장
-    private List<Comment> comments = new ArrayList<Comment>();
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, fetch = FetchType.LAZY) // Post 저장시 연관되어 있는 Comment들도 함께 저장
+    private Set<Comment> comments;
 }

--- a/src/main/java/apptive/team1/friendly/domain/post/repository/CommentRepository.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/repository/CommentRepository.java
@@ -1,14 +1,16 @@
 package apptive.team1.friendly.domain.post.repository;
 
 import apptive.team1.friendly.domain.post.entity.Comment;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 
 @Repository
+@RequiredArgsConstructor
 public class CommentRepository {
 
-    EntityManager em;
+    private final EntityManager em;
 
     /**
      * 댓글 작성, 수정

--- a/src/main/java/apptive/team1/friendly/domain/post/repository/PostRepository.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/repository/PostRepository.java
@@ -52,14 +52,16 @@ public class PostRepository {
      * 게시물 찾기
      */
     public Post findOneByPostId(Long postId) {
-        return em.find(Post.class, postId);
+        return em.createQuery("select p from Post p join fetch p.hashTag join fetch p.rules where p.id =: postId", Post.class)
+                .setParameter("postId", postId)
+                .getSingleResult();
     }
 
     /**
      * 전체 게시물 조회
      */
     public List<Post> findAll() {
-        return em.createQuery("select p from Post p", Post.class)
+        return em.createQuery("select p from Post p join fetch p.hashTag join fetch p.rules", Post.class)
                 .getResultList();
     }
 

--- a/src/main/java/apptive/team1/friendly/domain/post/service/CommentService.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/service/CommentService.java
@@ -7,22 +7,32 @@ import apptive.team1.friendly.domain.post.repository.CommentRepository;
 import apptive.team1.friendly.domain.post.repository.PostRepository;
 import apptive.team1.friendly.domain.user.data.entity.Account;
 import apptive.team1.friendly.domain.user.data.repository.AccountRepository;
-import apptive.team1.friendly.global.utils.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CommentService {
 
     private final PostRepository postRepository;
     private final AccountRepository accountRepository;
     private final CommentRepository commentRepository;
+
+    @Transactional
     public Long addComment(CommentFormDto commentFormDto, Long postId) {
         // 현재 로그인된 사용자 확인
-        Account author = SecurityUtil.getCurrentUserName().flatMap(accountRepository::findOneWithAccountAuthoritiesByEmail).orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
+//        Account author = SecurityUtil.getCurrentUserName().flatMap(accountRepository::findOneWithAccountAuthoritiesByEmail).orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
+
+        // test용
+        Account author = new Account();
+        author.setEmail("test@test");
+        author.setFirstName("mw");
+        author.setLastName("mw2");
+        //
 
         // 댓글을 작성하는 게시물 확인
         Post post = postRepository.findOneByPostId(postId);

--- a/src/main/java/apptive/team1/friendly/domain/post/service/CommentService.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/service/CommentService.java
@@ -7,6 +7,7 @@ import apptive.team1.friendly.domain.post.repository.CommentRepository;
 import apptive.team1.friendly.domain.post.repository.PostRepository;
 import apptive.team1.friendly.domain.user.data.entity.Account;
 import apptive.team1.friendly.domain.user.data.repository.AccountRepository;
+import apptive.team1.friendly.global.utils.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,14 +26,7 @@ public class CommentService {
     @Transactional
     public Long addComment(CommentFormDto commentFormDto, Long postId) {
         // 현재 로그인된 사용자 확인
-//        Account author = SecurityUtil.getCurrentUserName().flatMap(accountRepository::findOneWithAccountAuthoritiesByEmail).orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
-
-        // test용
-        Account author = new Account();
-        author.setEmail("test@test");
-        author.setFirstName("mw");
-        author.setLastName("mw2");
-        //
+        Account author = SecurityUtil.getCurrentUserName().flatMap(accountRepository::findOneWithAccountAuthoritiesByEmail).orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
 
         // 댓글을 작성하는 게시물 확인
         Post post = postRepository.findOneByPostId(postId);

--- a/src/main/java/apptive/team1/friendly/domain/post/service/PostService.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/service/PostService.java
@@ -32,6 +32,8 @@ public class PostService {
     private final PostRepository postRepository;
     private final AccountRepository accountRepository;
     private final AccountPostRepository accountPostRepository;
+
+    // 유저 추가하는 테스트를 위해 임시 사용
     private final AccountLanguageRepository accountLanguageRepository;
     private final AccountNationRepository accountNationRepository;
     private final AccountProfileImgRepository accountProfileImgRepository;

--- a/src/main/java/apptive/team1/friendly/domain/post/service/PostService.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/service/PostService.java
@@ -10,6 +10,8 @@ import apptive.team1.friendly.domain.post.entity.Post;
 import apptive.team1.friendly.domain.post.repository.AccountPostRepository;
 import apptive.team1.friendly.domain.post.repository.PostRepository;
 import apptive.team1.friendly.domain.user.data.dto.AccountInfoResponse;
+import apptive.team1.friendly.domain.user.data.dto.profile.LanguageDto;
+import apptive.team1.friendly.domain.user.data.dto.profile.NationDto;
 import apptive.team1.friendly.domain.user.data.dto.profile.ProfileImgDto;
 import apptive.team1.friendly.domain.user.data.entity.Account;
 import apptive.team1.friendly.domain.user.data.entity.profile.*;
@@ -79,42 +81,42 @@ public class PostService {
     @Transactional
     public Long addPost(PostFormDto postFormDto) {
         // author 찾기
-        Account author = SecurityUtil.getCurrentUserName().flatMap(accountRepository::findOneWithAccountAuthoritiesByEmail).orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
+//        Account author = SecurityUtil.getCurrentUserName().flatMap(accountRepository::findOneWithAccountAuthoritiesByEmail).orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
 
         // test용
-//        Account author = new Account();
-//        author.setEmail("test@test");
-//        author.setFirstName("mw");
-//        author.setLastName("mw2");
-//
-//        AccountNation accountNation = new AccountNation();
-//        accountNation.setAccount(author);
-//        Nation nation = new Nation();
-//        nation.setName("korea");
-//        accountNation.setNation(nation);
-//        nationRepository.save(nation);
-//        accountNationRepository.save(accountNation);
-//
-//        ProfileImg profileImg = new ProfileImg();
-//        profileImg.setUploadFileUrl("test");
-//        profileImg.setAccount(author);
-//
-//        accountProfileImgRepository.save(profileImg);
-//
-//        AccountLanguage accountLanguage1 = new AccountLanguage();
-//        AccountLanguage accountLanguage2 = new AccountLanguage();
-//        Language language1 = new Language();
-//        Language language2 = new Language();
-//        language1.setName("korean");
-//        language2.setName("english");
-//        languageRepository.save(language1);
-//        languageRepository.save(language2);
-//        accountLanguage1.setLanguage(language1);
-//        accountLanguage2.setLanguage(language2);
-//        accountLanguage1.setAccount(author);
-//        accountLanguage2.setAccount(author);
-//        accountLanguageRepository.save(accountLanguage1);
-//        accountLanguageRepository.save(accountLanguage2);
+        Account author = new Account();
+        author.setEmail("test@test");
+        author.setFirstName("mw");
+        author.setLastName("mw2");
+
+        AccountNation accountNation = new AccountNation();
+        accountNation.setAccount(author);
+        Nation nation = new Nation();
+        nation.setName("korea");
+        accountNation.setNation(nation);
+        nationRepository.save(nation);
+        accountNationRepository.save(accountNation);
+
+        ProfileImg profileImg = new ProfileImg();
+        profileImg.setUploadFileUrl("test");
+        profileImg.setAccount(author);
+
+        accountProfileImgRepository.save(profileImg);
+
+        AccountLanguage accountLanguage1 = new AccountLanguage();
+        AccountLanguage accountLanguage2 = new AccountLanguage();
+        Language language1 = new Language();
+        Language language2 = new Language();
+        language1.setName("korean");
+        language2.setName("english");
+        languageRepository.save(language1);
+        languageRepository.save(language2);
+        accountLanguage1.setLanguage(language1);
+        accountLanguage2.setLanguage(language2);
+        accountLanguage1.setAccount(author);
+        accountLanguage2.setAccount(author);
+        accountLanguageRepository.save(accountLanguage1);
+        accountLanguageRepository.save(accountLanguage2);
         //
 
         Post post = new Post(
@@ -146,16 +148,10 @@ public class PostService {
     @Transactional
     public Long deletePost(Long postId) {
         // author 찾기
-        Account author = SecurityUtil.getCurrentUserName().flatMap(accountRepository::findOneWithAccountAuthoritiesByEmail).orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
-        // test용
-//        Account author = new Account();
-//        author.setEmail("test@test");
-//        author.setFirstName("mw");
-//        author.setLastName("mw2");
-        //
+//        Account author = SecurityUtil.getCurrentUserName().flatMap(accountRepository::findOneWithAccountAuthoritiesByEmail).orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
 
         // 삭제한 post의 id 리턴. test용 9번 아이디 user
-        return accountPostRepository.delete(author.getId(), postId);
+        return accountPostRepository.delete(21L, postId);
 
     }
 
@@ -165,13 +161,13 @@ public class PostService {
     @Transactional
     public Long updatePost(Long postId, PostFormDto updatePostDto) {
         // author 찾기
-        Account author = SecurityUtil.getCurrentUserName().flatMap(accountRepository::findOneWithAccountAuthoritiesByEmail).orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
+//        Account author = SecurityUtil.getCurrentUserName().flatMap(accountRepository::findOneWithAccountAuthoritiesByEmail).orElseThrow(() -> new RuntimeException("회원을 찾을 수 없습니다."));
 
         // postId에 해당하는 AccountPost 찾기
         AccountPost findAccountPost = accountPostRepository.findOneByPostId(postId);
 
         // 현재 로그인된 user와 게시글의 user가 다르면 예외 처리
-        if(author.getId() != findAccountPost.getUser().getId())
+        if(21 != findAccountPost.getUser().getId())
             throw new RuntimeException("권한이 없습니다."); // 본인 게시물 아니면 수정 불가
 
         // AccountPost와 연관된 post 찾음
@@ -202,14 +198,22 @@ public class PostService {
         Account postOwner = accountPost.getUser();
 
         // 글 작성자 정보 찾기
-        Optional<AccountNation> nation = accountNationRepository.findOneByAccount(postOwner);
+        Optional<AccountNation> nationOptional = accountNationRepository.findOneByAccount(postOwner);
         List<AccountLanguage> accountLanguages = accountLanguageRepository.findAllByAccount(postOwner);
         Optional<ProfileImg> profileImgOptional = accountProfileImgRepository.findOneByAccount(postOwner);
 
+        // nation 설정
+        AccountNation accountNation = nationOptional.get();
+        NationDto nationDto = new NationDto();
+        nationDto.setCity(accountNation.getCity());
+        nationDto.setName(accountNation.getNation().getName());
+
         // language 설정
-        List<String> languages = new ArrayList<>();
+        List<LanguageDto> languages = new ArrayList<>();
         for(AccountLanguage al : accountLanguages) {
-            languages.add(al.getLanguage().getName());
+            LanguageDto languageDto = new LanguageDto();
+            languageDto.setName(al.getLanguage().getName());
+//            languageDto.setLevel(al.getLevel());
         }
 
         // profileDto 설정
@@ -225,9 +229,12 @@ public class PostService {
         // postDto 설정
         PostDto postDto = new PostDto();
         // user 정보
-        postDto.setNation(nation.get().getNation().getName());
+        postDto.setNationDto(nationDto);
         postDto.setProfileImgDto(profileImgDto);
-        postDto.setLanguages(languages);
+        postDto.setLanguageDtoList(languages);
+        postDto.setFirstName(postOwner.getFirstName());
+        postDto.setLastName(postOwner.getLastName());
+//        postDto.setGender(postOwner.getGender().getName());
         // 게시글 정보
         postDto.setPostId(findPost.getId());
         postDto.setTitle(findPost.getTitle());

--- a/src/main/java/apptive/team1/friendly/domain/post/service/PostService.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/service/PostService.java
@@ -1,5 +1,4 @@
 package apptive.team1.friendly.domain.post.service;
-
 import apptive.team1.friendly.domain.post.dto.CommentDto;
 import apptive.team1.friendly.domain.post.dto.PostDto;
 import apptive.team1.friendly.domain.post.dto.PostFormDto;
@@ -9,15 +8,9 @@ import apptive.team1.friendly.domain.post.entity.Comment;
 import apptive.team1.friendly.domain.post.entity.Post;
 import apptive.team1.friendly.domain.post.repository.AccountPostRepository;
 import apptive.team1.friendly.domain.post.repository.PostRepository;
-import apptive.team1.friendly.domain.user.data.dto.AccountInfoResponse;
 import apptive.team1.friendly.domain.user.data.dto.PostOwnerInfo;
-import apptive.team1.friendly.domain.user.data.dto.profile.LanguageDto;
-import apptive.team1.friendly.domain.user.data.dto.profile.NationDto;
-import apptive.team1.friendly.domain.user.data.dto.profile.ProfileImgDto;
 import apptive.team1.friendly.domain.user.data.entity.Account;
-import apptive.team1.friendly.domain.user.data.entity.profile.*;
 import apptive.team1.friendly.domain.user.data.repository.*;
-import apptive.team1.friendly.domain.user.service.UserService;
 import apptive.team1.friendly.global.utils.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/apptive/team1/friendly/domain/user/data/dto/PostOwnerInfo.java
+++ b/src/main/java/apptive/team1/friendly/domain/user/data/dto/PostOwnerInfo.java
@@ -1,0 +1,24 @@
+package apptive.team1.friendly.domain.user.data.dto;
+
+import apptive.team1.friendly.domain.user.data.dto.profile.LanguageDto;
+import apptive.team1.friendly.domain.user.data.dto.profile.NationDto;
+import apptive.team1.friendly.domain.user.data.dto.profile.ProfileImgDto;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class PostOwnerInfo {
+    // 방장 정보
+    private String firstName;
+
+    private String lastName;
+
+    private String gender;
+
+    private NationDto nationDto;
+
+    private List<LanguageDto> languageDtoList;
+
+    private ProfileImgDto profileImgDto;
+}

--- a/src/main/java/apptive/team1/friendly/domain/user/service/UserService.java
+++ b/src/main/java/apptive/team1/friendly/domain/user/service/UserService.java
@@ -1,12 +1,13 @@
 package apptive.team1.friendly.domain.user.service;
 
+import apptive.team1.friendly.domain.post.entity.AccountPost;
+import apptive.team1.friendly.domain.post.repository.AccountPostRepository;
+import apptive.team1.friendly.domain.user.data.dto.*;
+import apptive.team1.friendly.domain.user.data.dto.profile.LanguageDto;
+import apptive.team1.friendly.domain.user.data.dto.profile.NationDto;
 import apptive.team1.friendly.global.common.jwt.JwtTokenProvider;
 import apptive.team1.friendly.global.common.s3.AwsS3Uploader;
 import apptive.team1.friendly.global.common.s3.FileInfo;
-import apptive.team1.friendly.domain.user.data.dto.AccountInfoResponse;
-import apptive.team1.friendly.domain.user.data.dto.GoogleSignUpRequest;
-import apptive.team1.friendly.domain.user.data.dto.SignupRequest;
-import apptive.team1.friendly.domain.user.data.dto.SignupResponse;
 import apptive.team1.friendly.domain.user.data.dto.profile.EntityToDtoConverter;
 import apptive.team1.friendly.domain.user.data.dto.profile.ProfileImgDto;
 import apptive.team1.friendly.domain.user.data.entity.Account;
@@ -22,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -42,6 +44,7 @@ public class UserService {
     private final AccountLanguageRepository accountLanguageRepository;
     private final AccountNationRepository accountNationRepository;
     private final AccountProfileImgRepository accountProfileImgRepository;
+    private final AccountPostRepository accountPostRepository;
 
     private final PasswordEncoder passwordEncoder;
     private final AwsS3Uploader awsS3Uploader;
@@ -292,5 +295,58 @@ public class UserService {
 
         // 회원 삭제
         accountRepository.delete(account);
+    }
+
+    /**
+     * 게시물 주인 정보 조회
+     */
+    public PostOwnerInfo getPostOwnerInfo(Long postId) {
+        PostOwnerInfo postOwnerInfo = new PostOwnerInfo();
+
+        // postId로 accountPost 찾아서 글 작성자를 찾음
+        AccountPost accountPost = accountPostRepository.findOneByPostId(postId);
+        Account postOwner = accountPost.getUser();
+
+        // 글 작성자 정보 찾기
+        Optional<AccountNation> nationOptional = accountNationRepository.findOneByAccount(postOwner);
+        List<AccountLanguage> accountLanguages = accountLanguageRepository.findAllByAccount(postOwner);
+        Optional<ProfileImg> profileImgOptional = accountProfileImgRepository.findOneByAccount(postOwner);
+
+        // language 설정
+        List<LanguageDto> languageDtoList = new ArrayList<>();
+        for(AccountLanguage al : accountLanguages) {
+            LanguageDto languageDto = new LanguageDto();
+            languageDto.setName(al.getLanguage().getName());
+            languageDto.setLevel(al.getLevel().getName());
+            languageDtoList.add(languageDto);
+        }
+
+        // nation 설정
+        if(nationOptional.isPresent()) {
+            AccountNation accountNation = nationOptional.get();
+            NationDto nationDto = new NationDto();
+            nationDto.setCity(accountNation.getCity());
+            nationDto.setName(accountNation.getNation().getName());
+            postOwnerInfo.setNationDto(nationDto);
+        }
+
+        // profileDto 설정
+        if(profileImgOptional.isPresent()) {
+            ProfileImg profileImg = profileImgOptional.get();
+            ProfileImgDto profileImgDto = new ProfileImgDto();
+            profileImgDto.setEmail(profileImg.getAccount().getEmail());
+            profileImgDto.setUploadFileName(profileImg.getUploadFileName());
+            profileImgDto.setOriginalFileName(profileImg.getOriginalFileName());
+            profileImgDto.setUploadFilePath(profileImg.getUploadFilePath());
+            profileImgDto.setUploadFileUrl(profileImg.getUploadFileUrl());
+            postOwnerInfo.setProfileImgDto(profileImgDto);
+        }
+
+        postOwnerInfo.setFirstName(postOwner.getFirstName());
+        postOwnerInfo.setLastName(postOwner.getLastName());
+//        postOwnerInfo.setGender(postOwner.getGender());
+        postOwnerInfo.setLanguageDtoList(languageDtoList);
+
+        return postOwnerInfo;
     }
 }

--- a/src/main/java/apptive/team1/friendly/global/config/SecurityConfig.java
+++ b/src/main/java/apptive/team1/friendly/global/config/SecurityConfig.java
@@ -54,6 +54,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/api/google/login", "/api/google/signup").permitAll()
                 .antMatchers("/auth/social/GOOGLE", "/auth/social/KAKAO").permitAll()
                 .antMatchers("/auth/social/GOOGLE/callback", "/auth/social/KAKAO/callback").permitAll()
+                .antMatchers("/posts").permitAll()
+                .antMatchers("/posts/*").permitAll()
+//                .antMatchers("/posts/9").permitAll()
+//                .antMatchers("/posts/9/comments").permitAll()
+                .antMatchers("/posts/*/comments").permitAll()
                 .anyRequest().authenticated()
                 // jwt filter config
                 .and()

--- a/src/main/java/apptive/team1/friendly/global/config/SecurityConfig.java
+++ b/src/main/java/apptive/team1/friendly/global/config/SecurityConfig.java
@@ -54,11 +54,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/api/google/login", "/api/google/signup").permitAll()
                 .antMatchers("/auth/social/GOOGLE", "/auth/social/KAKAO").permitAll()
                 .antMatchers("/auth/social/GOOGLE/callback", "/auth/social/KAKAO/callback").permitAll()
-                .antMatchers("/posts").permitAll()
-                .antMatchers("/posts/*").permitAll()
-//                .antMatchers("/posts/9").permitAll()
-//                .antMatchers("/posts/9/comments").permitAll()
-                .antMatchers("/posts/*/comments").permitAll()
                 .anyRequest().authenticated()
                 // jwt filter config
                 .and()

--- a/src/test/java/apptive/team1/friendly/PostService/PostServiceTest.java
+++ b/src/test/java/apptive/team1/friendly/PostService/PostServiceTest.java
@@ -20,7 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static apptive.team1.friendly.domain.post.entity.HashTag.LIFE;
 import static apptive.team1.friendly.domain.post.entity.HashTag.NATIVE;
@@ -90,10 +92,10 @@ public class PostServiceTest {
 
     @Test
     public void 게시물_조회() {
-        List<String> rules = new ArrayList<String>();
+        Set<String> rules = new HashSet<>();
         rules.add("rule1");
         rules.add("rule2");
-        List<HashTag> hashTag = new ArrayList<HashTag>();
+        Set<HashTag> hashTag = new HashSet<>();
         hashTag.add(LIFE);
         hashTag.add(NATIVE);
 

--- a/src/test/java/apptive/team1/friendly/PostService/PostServiceTest.java
+++ b/src/test/java/apptive/team1/friendly/PostService/PostServiceTest.java
@@ -7,6 +7,8 @@ import apptive.team1.friendly.domain.post.entity.HashTag;
 import apptive.team1.friendly.domain.post.entity.Post;
 import apptive.team1.friendly.domain.post.repository.PostRepository;
 import apptive.team1.friendly.domain.post.service.PostService;
+import apptive.team1.friendly.domain.user.data.entity.Account;
+import apptive.team1.friendly.domain.user.data.entity.profile.*;
 import apptive.team1.friendly.domain.user.data.repository.AccountRepository;
 import apptive.team1.friendly.domain.user.service.UserService;
 import org.junit.Assert;
@@ -129,5 +131,30 @@ public class PostServiceTest {
 
         postService.updatePost(4L, postFormDto);
 
+    }
+
+    @Test
+    public void 테스트용_회원추가() {
+        Account account = new Account();
+        AccountNation accountNation = new AccountNation();
+        accountNation.setAccount(account);
+        Nation nation = new Nation();
+        nation.setName("korea");
+        accountNation.setNation(nation);
+
+        ProfileImg profileImg = new ProfileImg();
+        profileImg.setUploadFileUrl("test");
+        profileImg.setAccount(account);
+
+        AccountLanguage accountLanguage1 = new AccountLanguage();
+        AccountLanguage accountLanguage2 = new AccountLanguage();
+        Language language1 = new Language();
+        Language language2 = new Language();
+        language1.setName("korean");
+        language2.setName("english");
+        accountLanguage1.setLanguage(language1);
+        accountLanguage2.setLanguage(language2);
+        accountLanguage1.setAccount(account);
+        accountLanguage2.setAccount(account);
     }
 }


### PR DESCRIPTION
# 변경점 👍
- postservice에서 게시물 상세 조회하는 로직 변경
- user 도메인에 게시물 작성자 정보를 저장하는 DTO 추가
- userservice에 게시물 작성자 정보 DTO를 생성, 빈환하는 메소드 추가
- postcontroller의 게시물 상세 조회 메소드 수정

# 리팩토링 🛠
- 기존: postservice의 postDetail 메소드 내에서 게시물 작성자 정보 조회후, 유저 정보를 담는 DTO 생성하여 PostDto와 연관관계를 맺어주었음. 즉, postservice 내에서 userservice의 역할을 수행중이었음.
- 수정 후: postcontroller에서 userservice를 이용하여 게시물 작성자를 조회하고, postservice의 postDetail 메소드에 매개변수로 전달
 
# 스크린샷 🖼
![image](https://github.com/ApptiveDev/apptive-18th-friendly-backend/assets/100478309/4e79a421-4340-4a10-b5f4-8e57d4702ae9)

 # 비고 ✏
피드백 감사합니당
더 고칠점 있으면 말해줘~!
