### PR TITLE
feat: 게시물 참가신청 관련 버그 수정

### DIFF
--- a/src/main/java/apptive/team1/friendly/domain/post/controller/PostController.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/controller/PostController.java
@@ -129,7 +129,7 @@ public class PostController {
     /**
      * 게시물 참가 신청
      */
-    @PostMapping("/posts/join/{postId}")
+    @PostMapping("/posts/{postId}/join")
     public ResponseEntity<Long> applyJoin(@PathVariable("postId") Long postId) {
         Long currentUserId = userService.getCurrentUser().getId();
         postJoinService.applyJoin(currentUserId, postId);
@@ -139,7 +139,7 @@ public class PostController {
     /**
      * 참가 취소
      */
-    @DeleteMapping("/posts/join/{postId}")
+    @DeleteMapping("/posts/{postId}/join")
     public ResponseEntity<Long> cancelJoin(@PathVariable("postId") Long postId) {
         Long currentUserId = userService.getCurrentUser().getId();
         postJoinService.cancelJoin(currentUserId, postId);

--- a/src/main/java/apptive/team1/friendly/domain/post/entity/Post.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/entity/Post.java
@@ -175,15 +175,10 @@ public class Post extends BaseEntity {
     }
 
     private void isParticipant(Account currentUser) {
-        boolean isParticipant = false;
         for (AccountPost accountPost : accountPosts) {
             if (Objects.equals(accountPost.getUser().getId(), currentUser.getId()) && accountPost.getAccountType() != AccountType.AUTHOR) {
-                isParticipant = true;
-                break;
+                throw new NotParticipantException("참여중인 이용자가 아닙니다.");
             }
-        }
-        if(!isParticipant) {
-            throw new NotParticipantException("참여중인 이용자가 아닙니다.");
         }
     }
 

--- a/src/main/java/apptive/team1/friendly/domain/post/exception/DuplicatedParticipateException.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/exception/DuplicatedParticipateException.java
@@ -1,0 +1,22 @@
+package apptive.team1.friendly.domain.post.exception;
+
+public class DuplicatedParticipateException extends RuntimeException {
+    public DuplicatedParticipateException() {
+    }
+
+    public DuplicatedParticipateException(String message) {
+        super(message);
+    }
+
+    public DuplicatedParticipateException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DuplicatedParticipateException(Throwable cause) {
+        super(cause);
+    }
+
+    public DuplicatedParticipateException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/apptive/team1/friendly/domain/user/data/repository/AccountRepository.java
+++ b/src/main/java/apptive/team1/friendly/domain/user/data/repository/AccountRepository.java
@@ -22,6 +22,6 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
     @Query("select distinct a from Account a left join fetch a.languages join AccountPost ap on ap.accountType = apptive.team1.friendly.domain.post.entity.AccountType.AUTHOR and ap.post.id = :postId where a.id = ap.user.id")
     Account findAuthorByPostId(@Param("postId") Long postId);
 
-    @Query("select distinct a from Account a left join fetch a.languages join AccountPost ap on ap.accountType = apptive.team1.friendly.domain.post.entity.AccountType.PARTICIPANT and ap.post.id = :postId")
+    @Query("select distinct a from Account a left join fetch a.languages join AccountPost ap on ap.post.id = :postId where ap.user.id = a.id")
     List<Account> getAccountsByPostId(@Param("postId") Long postId);
 }


### PR DESCRIPTION
# 버그 해결 💊
- 중복된 참가 신청 예외 추가
- 게시물에 참여된 유저 목록을 요청하는 쿼리 수정
- 게시물 작성자는 참여 취소를 할 수 없도록 수정
 

 
