### PR TITLE
refactor: 게시물 조회 예외처리 분리

### DIFF
--- a/src/main/java/apptive/team1/friendly/domain/post/entity/Post.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/entity/Post.java
@@ -175,10 +175,15 @@ public class Post extends BaseEntity {
     }
 
     private void isParticipant(Account currentUser) {
+        boolean isParticipant = false;
         for (AccountPost accountPost : accountPosts) {
             if (Objects.equals(accountPost.getUser().getId(), currentUser.getId()) && accountPost.getAccountType() != AccountType.AUTHOR) {
-                throw new NotParticipantException("참여중인 이용자가 아닙니다.");
+                isParticipant = true;
+                break;
             }
+        }
+        if(!isParticipant) {
+            throw new NotParticipantException("참여중인 이용자가 아닙니다.");
         }
     }
 

--- a/src/main/java/apptive/team1/friendly/domain/post/exception/NoAccountException.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/exception/NoAccountException.java
@@ -1,0 +1,22 @@
+package apptive.team1.friendly.domain.post.exception;
+
+public class NoAccountException extends RuntimeException {
+    public NoAccountException() {
+    }
+
+    public NoAccountException(String message) {
+        super(message);
+    }
+
+    public NoAccountException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NoAccountException(Throwable cause) {
+        super(cause);
+    }
+
+    public NoAccountException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/apptive/team1/friendly/domain/post/exception/NoPostException.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/exception/NoPostException.java
@@ -1,0 +1,22 @@
+package apptive.team1.friendly.domain.post.exception;
+
+public class NoPostException extends RuntimeException {
+    public NoPostException() {
+    }
+
+    public NoPostException(String message) {
+        super(message);
+    }
+
+    public NoPostException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NoPostException(Throwable cause) {
+        super(cause);
+    }
+
+    public NoPostException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/src/main/java/apptive/team1/friendly/domain/post/repository/PostRepository.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/repository/PostRepository.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import javax.persistence.EntityManager;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -65,10 +66,14 @@ public class PostRepository {
     /**
      * 게시물 찾기
      */
-    public Post findOneByPostId(Long postId) {
-        return em.createQuery("select distinct p from Post p left join fetch p.hashTags where p.id =: postId", Post.class)
+    public Optional<Post> findOneByPostId(Long postId) {
+        List<Post> posts = em.createQuery("select distinct p from Post p left join fetch p.hashTags where p.id =: postId", Post.class)
                 .setParameter("postId", postId)
-                .getSingleResult();
+                .getResultList();
+        if(posts.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(posts.get(0));
     }
 
     /**

--- a/src/main/java/apptive/team1/friendly/domain/post/service/PostCRUDService.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/service/PostCRUDService.java
@@ -42,7 +42,7 @@ public class PostCRUDService {
      * postId로 해당 게시물 찾기
      */
     public Post findByPostId(Long id) {
-        return postRepository.findOneByPostId(id);
+        return findExistingPost(postRepository, id);
     }
 
     /**
@@ -59,9 +59,9 @@ public class PostCRUDService {
 
         Account author = findExistingMember(accountRepository, authorId);
 
-        Post findPost = postRepository.findOneByPostId(postId);
+        Post findPost = findExistingPost(postRepository, postId);
 
-        List<Account> participants = accountRepository.getAccountsByPostId(postId);
+        List<Account> participants = accountRepository.findAccountsByPostId(postId);
 
         return PostDto.createPostDto(findPost, author, participants);
     }
@@ -91,7 +91,7 @@ public class PostCRUDService {
 
         Account currentUser = findExistingMember(accountRepository, currentUserId);
 
-        Post findPost = postRepository.findOneByPostId(postId);
+        Post findPost = findExistingPost(postRepository, postId);
 
         findPost.deleteImages(currentUser, awsS3Uploader);
 
@@ -106,7 +106,7 @@ public class PostCRUDService {
 
         Account currentUser = findExistingMember(accountRepository, currentUserId);
 
-        Post findPost = postRepository.findOneByPostId(postId);
+        Post findPost = findExistingPost(postRepository, postId);
 
         findPost.update(currentUser, updateForm);
 
@@ -123,7 +123,7 @@ public class PostCRUDService {
      */
     public PostFormDto getUpdateForm(Long postId) {
 
-        Post post = postRepository.findOneByPostId(postId);
+        Post post = findExistingPost(postRepository, postId);
 
         return PostFormDto.createPostFormDto(post);
     }

--- a/src/main/java/apptive/team1/friendly/domain/post/service/PostJoinService.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/service/PostJoinService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static apptive.team1.friendly.domain.post.service.PostServiceHelper.*;
+import static apptive.team1.friendly.domain.post.service.PostServiceHelper.findExistingPost;
 
 @Service
 @RequiredArgsConstructor
@@ -27,7 +28,7 @@ public class PostJoinService {
 
         Account currentUser = findExistingMember(accountRepository, currentUserId);
 
-        Post findPost = postRepository.findOneByPostId(postId);
+        Post findPost = findExistingPost(postRepository, postId);
 
         findPost.addParticipant(currentUser);
     }
@@ -37,7 +38,7 @@ public class PostJoinService {
 
         Account currentUser = findExistingMember(accountRepository, currentUserId);
 
-        Post findPost = postRepository.findOneByPostId(postId);
+        Post findPost = findExistingPost(postRepository, postId);
 
         findPost.deleteParticipant(currentUser);
     }

--- a/src/main/java/apptive/team1/friendly/domain/post/service/PostServiceHelper.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/service/PostServiceHelper.java
@@ -1,5 +1,9 @@
 package apptive.team1.friendly.domain.post.service;
 
+import apptive.team1.friendly.domain.post.entity.Post;
+import apptive.team1.friendly.domain.post.exception.NoAccountException;
+import apptive.team1.friendly.domain.post.exception.NoPostException;
+import apptive.team1.friendly.domain.post.repository.PostRepository;
 import apptive.team1.friendly.domain.user.data.entity.Account;
 import apptive.team1.friendly.domain.user.data.repository.AccountRepository;
 
@@ -11,8 +15,17 @@ public final class PostServiceHelper {
 
         Optional<Account> authorOptional = accountRepository.findOneWithAccountAuthoritiesById(accountId);
 
-        if(!authorOptional.isPresent()) throw new RuntimeException("존재하지 않는 user");
+        if(!authorOptional.isPresent()) throw new NoAccountException("존재하지 않는 유저입니다.");
 
         return authorOptional.get();
+    }
+
+    public static Post findExistingPost(PostRepository postRepository, Long postId) {
+
+        Optional<Post> postOptional = postRepository.findOneByPostId(postId);
+
+        if(!postOptional.isPresent())   throw new NoPostException("존재하지 않는 게시물입니다.");
+
+        return postOptional.get();
     }
 }

--- a/src/main/java/apptive/team1/friendly/domain/post/service/comment/CommentService.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/service/comment/CommentService.java
@@ -16,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
+import static apptive.team1.friendly.domain.post.service.PostServiceHelper.findExistingPost;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -31,7 +33,7 @@ public class CommentService {
         Account author = SecurityUtil.getCurrentUserName().flatMap(accountRepository::findOneWithAccountAuthoritiesByEmail).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         // 댓글을 작성하는 게시물 확인
-        Post post = postRepository.findOneByPostId(postId);
+        Post post = findExistingPost(postRepository, postId);
 
         // Comment 객체 생성하고 데이터 이동
         Comment newComment = Comment.builder()

--- a/src/main/java/apptive/team1/friendly/domain/user/data/repository/AccountRepository.java
+++ b/src/main/java/apptive/team1/friendly/domain/user/data/repository/AccountRepository.java
@@ -23,5 +23,5 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
     Account findAuthorByPostId(@Param("postId") Long postId);
 
     @Query("select distinct a from Account a left join fetch a.languages join AccountPost ap on ap.post.id = :postId where ap.user.id = a.id")
-    List<Account> getAccountsByPostId(@Param("postId") Long postId);
+    List<Account> findAccountsByPostId(@Param("postId") Long postId);
 }

--- a/src/test/java/apptive/team1/friendly/domain/account/service/UserServiceTest.java
+++ b/src/test/java/apptive/team1/friendly/domain/account/service/UserServiceTest.java
@@ -57,6 +57,6 @@ public class UserServiceTest {
 
         return Account.create("test@gmail.com", "abc", "kim", "mw",
                         "23-08-05", "남자", "intro", interests, "korea", "busan",
-                        languages, languageLevels, authority);
+                        languages, languageLevels, authority, "부산대");
     }
 }

--- a/src/test/java/apptive/team1/friendly/domain/post/service/PostServiceTest.java
+++ b/src/test/java/apptive/team1/friendly/domain/post/service/PostServiceTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Set;
 
 import static apptive.team1.friendly.domain.post.entity.HashTag.*;
+import static apptive.team1.friendly.domain.post.service.PostServiceHelper.findExistingPost;
 import static org.springframework.test.util.AssertionErrors.fail;
 
 @RunWith(SpringRunner.class)
@@ -66,7 +67,7 @@ public class PostServiceTest {
         Long postId = postCRUDService.addPost(account.getId(), newPostForm, files);
 
         // then
-        Assert.assertEquals("게시물 추가가 성공적으로 되어야 한다.", postId, postRepository.findOneByPostId(postId).getId());
+        Assert.assertEquals("게시물 추가가 성공적으로 되어야 한다.", postId, findExistingPost(postRepository, postId).getId());
     }
 
     @Test
@@ -156,7 +157,7 @@ public class PostServiceTest {
         PostDto postDto = postCRUDService.postDetail(postId, author.getId());
 
         // then
-        Post findPost = postRepository.findOneByPostId(postId);
+        Post findPost = findExistingPost(postRepository, postId);
         Assert.assertEquals("게시물 id와 조회한 id가 일치해야 한다.", postId, postDto.getPostId());
         Assert.assertEquals("게시물 title과 조회한 title이 일치해야 한다.", findPost.getTitle(), postDto.getTitle() );
     }
@@ -195,10 +196,10 @@ public class PostServiceTest {
 
         // when
         files.add(file);
-        Post post = postRepository.findOneByPostId(postId);
+        Post post = findExistingPost(postRepository, postId);
         String title = post.getTitle();
         Long updatedPostId = postCRUDService.updatePost(account.getId(), postId, updateFormDto, files);
-        Post updatedPost = postRepository.findOneByPostId(updatedPostId);
+        Post updatedPost = findExistingPost(postRepository, updatedPostId);
 
         // then
         Assert.assertEquals("업데이트 전과 후의 게시물 아이디는 동일하다",postId, updatedPostId);
@@ -290,7 +291,7 @@ public class PostServiceTest {
         postJoinService.applyJoin(participant.getId(), postId);
 
         //then
-        Post post = postRepository.findOneByPostId(postId);
+        Post post = findExistingPost(postRepository, postId);
         List<AccountPost> accountPosts = post.getAccountPosts();
         Assert.assertEquals("한 명이 참가신청을 하면 참가 인원은 2명이 되어야 한다.", 2, accountPosts.size());
         Assert.assertEquals("신청한 사람은 참여자가 되어야 한다.", AccountType.PARTICIPANT, accountPosts.get(accountPosts.size()-1).getAccountType());
@@ -337,7 +338,7 @@ public class PostServiceTest {
         postJoinService.cancelJoin(participant.getId(), postId);
 
         //then
-        Post post = postRepository.findOneByPostId(postId);
+        Post post = findExistingPost(postRepository, postId);;
         List<AccountPost> accountPosts = post.getAccountPosts();
         Assertions.assertEquals(1,accountPosts.size(), "참여 취소 시 참여 인원이 감소해야 한다.");
     }


### PR DESCRIPTION
# 리팩토링 🛠
- 게시물 조회 예외처리하는 부분을 별개의 메소드로 분리하여, service 메소드 내 추상화 수준을 동일하게 변경
 
# 스크린샷 🖼
![image](https://github.com/ApptiveDev/apptive-18th-friendly-backend/assets/100478309/bc0a489a-d2e5-407e-a40d-b0d018770f9d)
 
