### PR TITLE
feat: 게시물 상세페이지에 참여자 이미지 추가

### DIFF
--- a/src/main/java/apptive/team1/friendly/domain/post/dto/PostDto.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/dto/PostDto.java
@@ -2,7 +2,9 @@ package apptive.team1.friendly.domain.post.dto;
 import apptive.team1.friendly.domain.post.dto.comment.CommentDto;
 import apptive.team1.friendly.domain.post.entity.*;
 import apptive.team1.friendly.domain.post.entity.comment.Comment;
+import apptive.team1.friendly.domain.post.vo.Participant;
 import apptive.team1.friendly.domain.user.data.entity.Account;
+import apptive.team1.friendly.domain.user.data.entity.ProfileImg;
 import apptive.team1.friendly.global.common.s3.ImageDto;
 import apptive.team1.friendly.domain.user.data.dto.UserInfo;
 import lombok.AccessLevel;
@@ -17,7 +19,7 @@ import java.util.Set;
 @Data
 public class PostDto {
     @Builder(access = AccessLevel.PROTECTED)
-    public PostDto(Long postId, List<ImageDto> postImages, List<Long> participantIds, UserInfo authorInfo,
+    public PostDto(Long postId, List<ImageDto> postImages, List<Participant> participants, UserInfo authorInfo,
                    String title, Set<HashTag> hashTags, int maxPeople, String description,
                    LocalDate startDate, LocalDate endDate, String location, Set<String> rules,
                    List<CommentDto> comments) {
@@ -30,7 +32,7 @@ public class PostDto {
         this.startDate = startDate;
         this.endDate = endDate;
         this.location = location;
-        this.participantIds = participantIds;
+        this.participants = participants;
         this.postImages.addAll(postImages);
         this.comments.addAll(comments);
         this.hashTags.addAll(hashTags);
@@ -41,7 +43,7 @@ public class PostDto {
 
     private List<ImageDto> postImages = new ArrayList<>();
 
-    private List<Long> participantIds;
+    private List<Participant> participants;
 
     private UserInfo authorInfo;
 
@@ -70,9 +72,15 @@ public class PostDto {
 
         UserInfo authorInfo = UserInfo.create(author);
 
-        List<Long> participantIds = new ArrayList<>();
-        for (Account participant : participants) {
-            participantIds.add(participant.getId());
+        List<Participant> participantList = new ArrayList<>();
+        for (Account participantAccount : participants) { // 참여자 객체 생성 후 저장
+            ProfileImg profileImg = participantAccount.getProfileImg();
+            ImageDto imageDto = null;
+            if(profileImg != null) {
+                imageDto = new ImageDto(profileImg.getOriginalFileName(), profileImg.getUploadFileName(), profileImg.getUploadFilePath(), profileImg.getUploadFileUrl());
+            }
+            Participant participant = new Participant(participantAccount.getId(), imageDto);
+            participantList.add(participant);
         }
 
         List<ImageDto> postImageDtos = new ArrayList<>(); // 게시물 이미지 DTO 리스트
@@ -91,7 +99,7 @@ public class PostDto {
 
         return PostDto.builder()
                 .authorInfo(authorInfo)
-                .participantIds(participantIds)
+                .participants(participantList)
                 .postId(findPost.getId())
                 .title(findPost.getTitle())
                 .maxPeople(findPost.getMaxPeople())

--- a/src/main/java/apptive/team1/friendly/domain/post/vo/Participant.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/vo/Participant.java
@@ -1,0 +1,19 @@
+package apptive.team1.friendly.domain.post.vo;
+
+import apptive.team1.friendly.global.common.s3.ImageDto;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class Participant {
+
+    public Participant(Long id, ImageDto profileImg) {
+        this.id = id;
+        this.profileImgDto = profileImg;
+    }
+
+    private Long id;
+
+    private ImageDto profileImgDto;
+
+}

--- a/src/main/java/apptive/team1/friendly/domain/post/vo/Participant.java
+++ b/src/main/java/apptive/team1/friendly/domain/post/vo/Participant.java
@@ -15,5 +15,4 @@ public class Participant {
     private Long id;
 
     private ImageDto profileImgDto;
-
 }

--- a/src/main/java/apptive/team1/friendly/domain/user/service/UserService.java
+++ b/src/main/java/apptive/team1/friendly/domain/user/service/UserService.java
@@ -165,6 +165,7 @@ public class UserService {
      * 게시물 주인 정보 조회
      */
     public Account getPostOwner(Long postId) {
+        System.out.println("postId = " + postId);
         return accountRepository.findAuthorByPostId(postId);
     }
 


### PR DESCRIPTION
# 변경점 👍
- 게시물 상세페이지에 참여자에 대한 id와 이미지를 제공하기 위해 Participant VO를 생성하여 값을 담아서 제공
 
# 스크린샷
![image](https://github.com/ApptiveDev/apptive-18th-friendly-backend/assets/100478309/14cf3145-a941-442f-9dc2-6abe2aa31d70)
id와 profileImage를 가지는 Participant VO

# 비고
- Participant를 user도메인에 넣는게 좋을까 post에 넣는게 좋을까? 